### PR TITLE
feature: drag date range without direction limit

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -87,6 +87,7 @@ import CloseOnScrollCallback from "../../examples/closeOnScrollCallback";
 import SelectsRange from "../../examples/selectsRange";
 import selectsRangeWithDisabledDates from "../../examples/selectsRangeWithDisabledDates";
 import CalendarStartDay from "../../examples/calendarStartDay";
+import DateRangeIgnoreDirection from "../../examples/dateRangeIgnoreDirection";
 
 import "./style.scss";
 import "react-datepicker/dist/react-datepicker.css";
@@ -205,6 +206,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Date Range with Portal",
       component: DateRangeWithPortal,
+    },
+    {
+      title: "Date Range without direction",
+      component: DateRangeIgnoreDirection,
     },
     {
       title: "Disable datepicker",

--- a/docs-site/src/examples/dateRangeIgnoreDirection.js
+++ b/docs-site/src/examples/dateRangeIgnoreDirection.js
@@ -1,0 +1,15 @@
+() => {
+  const [dateRange, setDateRange] = useState([null, null]);
+  const [startDate, endDate] = dateRange;
+  return (
+    <DatePicker
+      selectsRange={true}
+      startDate={startDate}
+      endDate={endDate}
+      onChange={(update) => {
+        setDateRange(update);
+      }}
+      ignoreRangeDirection={true}
+    />
+  );
+};

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -198,6 +198,7 @@ export default class Calendar extends React.Component {
     customTimeInput: PropTypes.element,
     weekAriaLabelPrefix: PropTypes.string,
     setPreSelection: PropTypes.func,
+    ignoreRangeDirection: PropTypes.bool,
   };
 
   constructor(props) {
@@ -898,6 +899,7 @@ export default class Calendar extends React.Component {
             containerRef={this.containerRef}
             monthShowsDuplicateDaysEnd={monthShowsDuplicateDaysEnd}
             monthShowsDuplicateDaysStart={monthShowsDuplicateDaysStart}
+            ignoreRangeDirection={this.props.ignoreRangeDirection}
           />
         </div>
       );

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -745,3 +745,13 @@ export function getYearsPeriod(
   const startPeriod = endPeriod - (yearItemNumber - 1);
   return { startPeriod, endPeriod };
 }
+
+export function getValidDateRange(start, end) {
+  if (!start) {
+    return [end, null];
+  }
+  if (!end) {
+    return [start, end];
+  }
+  return isAfter(start, end) ? [end, start] : [start, end];
+}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -15,6 +15,7 @@ import {
   isAfter,
   getDayOfWeekCode,
   formatDate,
+  getValidDateRange,
 } from "./date_utils";
 
 export default class Day extends React.Component {
@@ -51,6 +52,7 @@ export default class Day extends React.Component {
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object }),
     ]),
+    ignoreRangeDirection: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -125,6 +127,7 @@ export default class Day extends React.Component {
       selectsDisabledDaysInRange,
       startDate,
       endDate,
+      ignoreRangeDirection,
     } = this.props;
 
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
@@ -135,6 +138,11 @@ export default class Day extends React.Component {
       (!selectsDisabledDaysInRange && this.isDisabled())
     ) {
       return false;
+    }
+
+    if (selectsRange && startDate && !endDate && ignoreRangeDirection) {
+      const [start, end] = getValidDateRange(startDate, selectingDate);
+      return isDayInRange(day, start, end);
     }
 
     if (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -38,6 +38,7 @@ import {
   setDefaultLocale,
   getDefaultLocale,
   DEFAULT_YEAR_ITEM_NUMBER,
+  getValidDateRange,
 } from "./date_utils";
 import onClickOutside from "react-onclickoutside";
 
@@ -123,6 +124,7 @@ export default class DatePicker extends React.Component {
       excludeScrollbar: true,
       customTimeInput: null,
       calendarStartDay: undefined,
+      ignoreRangeDirection: false,
     };
   }
 
@@ -284,6 +286,7 @@ export default class DatePicker extends React.Component {
     enableTabLoop: PropTypes.bool,
     customTimeInput: PropTypes.element,
     weekAriaLabelPrefix: PropTypes.string,
+    ignoreRangeDirection: PropTypes.bool,
   };
 
   constructor(props) {
@@ -527,7 +530,8 @@ export default class DatePicker extends React.Component {
     if (changedDate !== null && isDayDisabled(changedDate, this.props)) {
       return;
     }
-    const { onChange, selectsRange, startDate, endDate } = this.props;
+    const { onChange, selectsRange, startDate, endDate, ignoreRangeDirection } =
+      this.props;
 
     if (
       !isEqual(this.props.selected, changedDate) ||
@@ -564,10 +568,15 @@ export default class DatePicker extends React.Component {
         if (noRanges) {
           onChange([changedDate, null], event);
         } else if (hasStartRange) {
-          if (isBefore(changedDate, startDate)) {
-            onChange([changedDate, null], event);
+          if (ignoreRangeDirection) {
+            const validDateRange = getValidDateRange(changedDate, startDate);
+            onChange(validDateRange, event);
           } else {
-            onChange([startDate, changedDate], event);
+            if (isBefore(changedDate, startDate)) {
+              onChange([changedDate, null], event);
+            } else {
+              onChange([startDate, changedDate], event);
+            }
           }
         }
         if (isRangeFilled) {
@@ -957,6 +966,7 @@ export default class DatePicker extends React.Component {
         isInputFocused={this.state.focused}
         customTimeInput={this.props.customTimeInput}
         setPreSelection={this.setPreSelection}
+        ignoreRangeDirection={this.props.ignoreRangeDirection}
       >
         {this.props.children}
       </WrappedCalendar>

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -71,6 +71,7 @@ export default class Month extends React.Component {
     ]),
     monthShowsDuplicateDaysEnd: PropTypes.bool,
     monthShowsDuplicateDaysStart: PropTypes.bool,
+    ignoreRangeDirection: PropTypes.bool,
   };
 
   MONTH_REFS = [...Array(12)].map(() => React.createRef());
@@ -205,6 +206,7 @@ export default class Month extends React.Component {
           calendarStartDay={this.props.calendarStartDay}
           monthShowsDuplicateDaysEnd={this.props.monthShowsDuplicateDaysEnd}
           monthShowsDuplicateDaysStart={this.props.monthShowsDuplicateDaysStart}
+          ignoreRangeDirection={this.props.ignoreRangeDirection}
         />
       );
 

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -63,6 +63,7 @@ export default class Week extends React.Component {
     ]),
     monthShowsDuplicateDaysEnd: PropTypes.bool,
     monthShowsDuplicateDaysStart: PropTypes.bool,
+    ignoreRangeDirection: PropTypes.bool,
   };
 
   handleDayClick = (day, event) => {
@@ -156,6 +157,7 @@ export default class Week extends React.Component {
               this.props.monthShowsDuplicateDaysStart
             }
             locale={this.props.locale}
+            ignoreRangeDirection={this.props.ignoreRangeDirection}
           />
         );
       })


### PR DESCRIPTION
react-datepicker component support select end date at first, then select start date.  When triggle change callback, Covert to valid date range.